### PR TITLE
Created various driver control options

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -5,7 +5,9 @@
 
 package frc.robot;
 
+import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
+import swervelib.math.Matter;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -16,8 +18,17 @@ import edu.wpi.first.math.util.Units;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+    public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
+    public static final Matter CHASSIS    = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+    public static final double LOOP_TIME  = 0.13; //s, 20ms + 110ms SparkMax velocity lag
+
     public static class OperatorConstants {
         public static final int DRIVER_CONTROLLER_PORT = 0;
+        public static final double LEFT_X_DEADBAND = 0.01;
+        public static final double LEFT_Y_DEADBAND = 0.01;
+        public static final double RIGHT_X_DEADBAND = 0.01;
+        public static final double RIGHT_Y_DEADBAND = 0.01;
+        public static final double TURN_CONSTANT = 6;
     }
     public static class SwerveDrivetrainConstants {
         public static final String configFileDirectory = "swerve";

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,15 +5,19 @@
 
 package frc.robot;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Filesystem;
-import frc.robot.Constants.OperatorConstants;
-import frc.robot.commands.Autos;
-import frc.robot.commands.ExampleCommand;
-import frc.robot.subsystems.ExampleSubsystem;
-import frc.robot.subsystems.SwerveSubsystem;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.OperatorConstants;
+import frc.robot.commands.Autos;
+import frc.robot.commands.swerve.teleopControls.AbsoluteDrive;
+import frc.robot.commands.swerve.teleopControls.AbsoluteDriveAdv;
+import frc.robot.subsystems.ExampleSubsystem;
+import frc.robot.subsystems.SwerveSubsystem;
 
 import java.io.File;
 
@@ -28,12 +32,12 @@ public class RobotContainer {
     // The robot's subsystems and commands are defined here...
     private final ExampleSubsystem exampleSubsystem = new ExampleSubsystem();
 
-    private final SwerveSubsystem swerveSubsystem = new SwerveSubsystem(
-            new File(Filesystem.getDeployDirectory(), "swerve")
+    public final SwerveSubsystem swerveSubsystem = new SwerveSubsystem(
+            new File(Filesystem.getDeployDirectory(), Constants.SwerveDrivetrainConstants.configFileDirectory)
     );
 
     // Replace with CommandPS4Controller or CommandJoystick if needed
-    private final CommandXboxController driverController =
+    private final CommandXboxController driverXbox =
             new CommandXboxController(OperatorConstants.DRIVER_CONTROLLER_PORT);
     
     
@@ -41,6 +45,44 @@ public class RobotContainer {
     public RobotContainer() {
         // Configure the trigger bindings
         configureBindings();
+
+        AbsoluteDriveAdv closedAbsoluteDriveAdv = new AbsoluteDriveAdv(swerveSubsystem,
+                () -> MathUtil.applyDeadband(driverXbox.getLeftY(),
+                        OperatorConstants.LEFT_Y_DEADBAND),
+                () -> MathUtil.applyDeadband(driverXbox.getLeftX(),
+                        OperatorConstants.LEFT_X_DEADBAND),
+                () -> MathUtil.applyDeadband(driverXbox.getRightX(),
+                        OperatorConstants.RIGHT_X_DEADBAND),
+                driverXbox.getHID()::getPOV);
+
+        // Applies deadbands and inverts controls because joysticks
+        // are back-right positive while robot
+        // controls are front-left positive
+        // left stick controls translation
+        // right stick controls the desired angle NOT angular rotation
+        Command driveFieldOrientedDirectAngle = swerveSubsystem.driveCommand(
+                () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
+                () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
+                () -> driverXbox.getRightX(),
+                () -> -driverXbox.getRightY());
+
+        // Applies deadbands and inverts controls because joysticks
+        // are back-right positive while robot
+        // controls are front-left positive
+        // left stick controls translation
+        // right stick controls the angular velocity of the robot
+        Command driveFieldOrientedAngularVelocity = swerveSubsystem.driveCommand(
+                () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
+                () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
+                () -> driverXbox.getRawAxis(2));
+
+        Command driveFieldOrientedDirectAngleSim = swerveSubsystem.simDriveCommand(
+                () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
+                () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
+                () -> driverXbox.getRawAxis(2));
+
+        swerveSubsystem.setDefaultCommand(
+                !RobotBase.isSimulation() ? driveFieldOrientedDirectAngle : driveFieldOrientedDirectAngleSim);
     }
     
     
@@ -54,13 +96,7 @@ public class RobotContainer {
      * joysticks}.
      */
     private void configureBindings() {
-        // Schedule `ExampleCommand` when `exampleCondition` changes to `true`
-        new Trigger(exampleSubsystem::exampleCondition)
-                .onTrue(new ExampleCommand(exampleSubsystem));
-        
-        // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
-        // cancelling on release.
-        driverController.b().whileTrue(exampleSubsystem.exampleMethodCommand());
+        driverXbox.a().onTrue(Commands.runOnce(swerveSubsystem::zeroGyro));
     }
     
     

--- a/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteDrive.java
+++ b/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteDrive.java
@@ -1,0 +1,120 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.swerve.teleopControls;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.SwerveSubsystem;
+import java.util.List;
+import java.util.function.DoubleSupplier;
+import swervelib.SwerveController;
+import swervelib.math.SwerveMath;
+
+/**
+ * An example command that uses an example subsystem.
+ */
+public class AbsoluteDrive extends Command
+{
+
+    private final SwerveSubsystem swerve;
+    private final DoubleSupplier  vX, vY;
+    private final DoubleSupplier headingHorizontal, headingVertical;
+    private boolean initRotation = false;
+
+    /**
+     * Used to drive a swerve robot in full field-centric mode.  vX and vY supply translation inputs, where x is
+     * torwards/away from alliance wall and y is left/right. headingHorzontal and headingVertical are the Cartesian
+     * coordinates from which the robot's angle will be derived— they will be converted to a polar angle, which the robot
+     * will rotate to.
+     *
+     * @param swerve            The swerve drivebase subsystem.
+     * @param vX                DoubleSupplier that supplies the x-translation joystick input.  Should be in the range -1
+     *                          to 1 with deadband already accounted for.  Positive X is away from the alliance wall.
+     * @param vY                DoubleSupplier that supplies the y-translation joystick input.  Should be in the range -1
+     *                          to 1 with deadband already accounted for.  Positive Y is towards the left wall when
+     *                          looking through the driver station glass.
+     * @param headingHorizontal DoubleSupplier that supplies the horizontal component of the robot's heading angle. In the
+     *                          robot coordinate system, this is along the same axis as vY. Should range from -1 to 1 with
+     *                          no deadband.  Positive is towards the left wall when looking through the driver station
+     *                          glass.
+     * @param headingVertical   DoubleSupplier that supplies the vertical component of the robot's heading angle.  In the
+     *                          robot coordinate system, this is along the same axis as vX.  Should range from -1 to 1
+     *                          with no deadband. Positive is away from the alliance wall.
+     */
+    public AbsoluteDrive(SwerveSubsystem swerve, DoubleSupplier vX, DoubleSupplier vY, DoubleSupplier headingHorizontal,
+                         DoubleSupplier headingVertical)
+    {
+        this.swerve = swerve;
+        this.vX = vX;
+        this.vY = vY;
+        this.headingHorizontal = headingHorizontal;
+        this.headingVertical = headingVertical;
+
+        addRequirements(swerve);
+    }
+
+    @Override
+    public void initialize()
+    {
+        initRotation = true;
+    }
+
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute()
+    {
+
+        // Get the desired chassis speeds based on a 2 joystick module.
+        ChassisSpeeds desiredSpeeds = swerve.getTargetSpeeds(vX.getAsDouble(), vY.getAsDouble(),
+                headingHorizontal.getAsDouble(),
+                headingVertical.getAsDouble());
+
+        // Prevent Movement After Auto
+        if (initRotation)
+        {
+            if (headingHorizontal.getAsDouble() == 0 && headingVertical.getAsDouble() == 0)
+            {
+                // Get the curretHeading
+                Rotation2d firstLoopHeading = swerve.getHeading();
+
+                // Set the Current Heading to the desired Heading
+                desiredSpeeds = swerve.getTargetSpeeds(0, 0, firstLoopHeading.getSin(), firstLoopHeading.getCos());
+            }
+            //Dont Init Rotation Again
+            initRotation = false;
+        }
+
+        // Limit velocity to prevent tippy
+        Translation2d translation = SwerveController.getTranslation2d(desiredSpeeds);
+        translation = SwerveMath.limitVelocity(translation, swerve.getFieldVelocity(), swerve.getPose(),
+                Constants.LOOP_TIME, Constants.ROBOT_MASS, List.of(Constants.CHASSIS),
+                swerve.getSwerveDriveConfiguration());
+        SmartDashboard.putNumber("LimitedTranslation", translation.getX());
+        SmartDashboard.putString("Translation", translation.toString());
+
+        // Make the robot move
+        swerve.drive(translation, desiredSpeeds.omegaRadiansPerSecond, true);
+
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted)
+    {
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished()
+    {
+        return false;
+    }
+
+
+}

--- a/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteDriveAdv.java
+++ b/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteDriveAdv.java
@@ -1,0 +1,146 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.swerve.teleopControls;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.SwerveSubsystem;
+import java.util.List;
+import java.util.function.DoubleSupplier;
+import swervelib.SwerveController;
+import swervelib.math.SwerveMath;
+
+/**
+ * A more advanced Swerve Control System that has 4 buttons for which direction to face
+ */
+public class AbsoluteDriveAdv extends Command
+{
+
+    private final SwerveSubsystem swerve;
+    private final DoubleSupplier  vX, vY;
+    private final DoubleSupplier  headingAdjust;
+    private final DoubleSupplier POV;
+    private       boolean         resetHeading = false;
+
+    /**
+     * Used to drive a swerve robot in full field-centric mode.  vX and vY supply translation inputs, where x is
+     * towards/away from alliance wall and y is left/right. Heading Adjust changes the current heading after being
+     * multipied by a constant. The look booleans are shortcuts to get the robot to face a certain direction. Based off of
+     * ideas in https://www.chiefdelphi.com/t/experiments-with-a-swerve-steering-knob/446172
+     *
+     * @param swerve        The swerve drivebase subsystem.
+     * @param vX            DoubleSupplier that supplies the x-translation joystick input.  Should be in the range -1 to 1
+     *                      with deadband already accounted for.  Positive X is away from the alliance wall.
+     * @param vY            DoubleSupplier that supplies the y-translation joystick input.  Should be in the range -1 to 1
+     *                      with deadband already accounted for.  Positive Y is towards the left wall when looking through
+     *                      the driver station glass.
+     * @param headingAdjust DoubleSupplier that supplies the component of the robot's heading angle that should be
+     *                      adjusted. Should range from -1 to 1 with deadband already accounted for.
+     * @param POV           The POV axis on the controller, used for quickly spinning to a location
+     */
+    public AbsoluteDriveAdv(SwerveSubsystem swerve, DoubleSupplier vX, DoubleSupplier vY, DoubleSupplier headingAdjust,
+                            DoubleSupplier POV)
+    {
+        this.swerve = swerve;
+        this.vX = vX;
+        this.vY = vY;
+        this.headingAdjust = headingAdjust;
+        this.POV = POV;
+
+        addRequirements(swerve);
+    }
+
+    @Override
+    public void initialize()
+    {
+        resetHeading = true;
+    }
+
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute()
+    {
+        double headingX = 0;
+        double headingY = 0;
+
+        double POVDegrees = POV.getAsDouble();
+
+        // Doesn't read the POV if it has no input (-1)
+        if (POVDegrees != -1) {
+            // These are written to allow combinations for 45 angles
+            // Face Away from Drivers (0°±45°)
+            if (POVDegrees >= 315 || POVDegrees <= 45) {
+                headingY = -1;
+            }
+            // Face Right
+            if (POVDegrees >= 45 && POVDegrees <= 135) {
+                headingX = 1;
+            }
+            // Face Left
+            if (POVDegrees >= 225 && POVDegrees <= 315) {
+                headingX = -1;
+            }
+            // Face Towards the Drivers
+            if (POVDegrees >= 135 && POVDegrees <= 225) {
+                headingY = 1;
+            }
+        }
+
+        // Prevent Movement After Auto
+        if (resetHeading)
+        {
+            if (headingX == 0 && headingY == 0 && Math.abs(headingAdjust.getAsDouble()) > 0)
+            {
+                // Get the current Heading
+                Rotation2d currentHeading = swerve.getHeading();
+
+                // Set the Current Heading to the desired Heading
+                headingX = currentHeading.getSin();
+                headingY = currentHeading.getCos();
+            }
+            //Don't reset Heading Again
+            resetHeading = false;
+        }
+
+        ChassisSpeeds desiredSpeeds = swerve.getTargetSpeeds(vX.getAsDouble(), vY.getAsDouble(), headingX, headingY);
+
+        // Limit velocity to prevent tippy
+        Translation2d translation = SwerveController.getTranslation2d(desiredSpeeds);
+        translation = SwerveMath.limitVelocity(translation, swerve.getFieldVelocity(), swerve.getPose(),
+                Constants.LOOP_TIME, Constants.ROBOT_MASS, List.of(Constants.CHASSIS),
+                swerve.getSwerveDriveConfiguration());
+        SmartDashboard.putNumber("LimitedTranslation", translation.getX());
+        SmartDashboard.putString("Translation", translation.toString());
+
+        // Make the robot move
+        if (headingX == 0 && headingY == 0 && Math.abs(headingAdjust.getAsDouble()) > 0)
+        {
+            resetHeading = true;
+            swerve.drive(translation, (Constants.OperatorConstants.TURN_CONSTANT * -headingAdjust.getAsDouble()), true);
+        } else
+        {
+            swerve.drive(translation, desiredSpeeds.omegaRadiansPerSecond, true);
+        }
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted)
+    {
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished()
+    {
+        return false;
+    }
+
+
+}

--- a/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteFieldDrive.java
+++ b/src/main/java/frc/robot/commands/swerve/teleopControls/AbsoluteFieldDrive.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.swerve.teleopControls;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.SwerveSubsystem;
+import java.util.List;
+import java.util.function.DoubleSupplier;
+import swervelib.SwerveController;
+import swervelib.math.SwerveMath;
+
+/**
+ * An example command that uses an example subsystem.
+ */
+public class AbsoluteFieldDrive extends Command
+{
+
+    private final SwerveSubsystem swerve;
+    private final DoubleSupplier  vX, vY, heading;
+
+    /**
+     * Used to drive a swerve robot in full field-centric mode.  vX and vY supply translation inputs, where x is
+     * towards/away from alliance wall and y is left/right. headingHorizontal and headingVertical are the Cartesian
+     * coordinates from which the robot's angle will be derived— they will be converted to a polar angle, which the robot
+     * will rotate to.
+     *
+     * @param swerve  The swerve drivebase subsystem.
+     * @param vX      DoubleSupplier that supplies the x-translation joystick input.  Should be in the range -1 to 1 with
+     *                deadband already accounted for.  Positive X is away from the alliance wall.
+     * @param vY      DoubleSupplier that supplies the y-translation joystick input.  Should be in the range -1 to 1 with
+     *                deadband already accounted for.  Positive Y is towards the left wall when looking through the driver
+     *                station glass.
+     * @param heading DoubleSupplier that supplies the robot's heading angle.
+     */
+    public AbsoluteFieldDrive(SwerveSubsystem swerve, DoubleSupplier vX, DoubleSupplier vY,
+                              DoubleSupplier heading) {
+        this.swerve = swerve;
+        this.vX = vX;
+        this.vY = vY;
+        this.heading = heading;
+
+        addRequirements(swerve);
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute() {
+
+        // Get the desired chassis speeds based on a 2 joystick module.
+
+        ChassisSpeeds desiredSpeeds = swerve.getTargetSpeeds(vX.getAsDouble(), vY.getAsDouble(),
+                new Rotation2d(heading.getAsDouble() * Math.PI));
+
+        // Limit velocity to prevent tippy
+        Translation2d translation = SwerveController.getTranslation2d(desiredSpeeds);
+        translation = SwerveMath.limitVelocity(translation, swerve.getFieldVelocity(), swerve.getPose(),
+                Constants.LOOP_TIME, Constants.ROBOT_MASS, List.of(Constants.CHASSIS),
+                swerve.getSwerveDriveConfiguration());
+        SmartDashboard.putNumber("LimitedTranslation", translation.getX());
+        SmartDashboard.putString("Translation", translation.toString());
+
+        // Make the robot move
+        swerve.drive(translation, desiredSpeeds.omegaRadiansPerSecond, true);
+
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+
+}

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -1,13 +1,21 @@
 package frc.robot.subsystems;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.SwerveDrivetrainConstants;
+import swervelib.SwerveController;
 import swervelib.SwerveDrive;
+import swervelib.parser.SwerveDriveConfiguration;
 import swervelib.parser.SwerveParser;
 import swervelib.telemetry.SwerveDriveTelemetry;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.function.DoubleSupplier;
 
 public class SwerveSubsystem extends SubsystemBase {
     /**
@@ -30,5 +38,224 @@ public class SwerveSubsystem extends SubsystemBase {
         } catch (IOException e) {
             throw new RuntimeException("Failed to read swerve configuration", e);
         }
+    }
+
+    /**
+     * Command to drive the robot using translative values and heading as a setpoint.
+     *
+     * @param translationX Translation in the X direction. Cubed for smoother controls.
+     * @param translationY Translation in the Y direction. Cubed for smoother controls.
+     * @param headingX     Heading X to calculate angle of the joystick.
+     * @param headingY     Heading Y to calculate angle of the joystick.
+     * @return Drive command.
+     */
+    public Command driveCommand(DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier headingX,
+                                DoubleSupplier headingY) {
+        // swerveDrive.setHeadingCorrection(true); // Normally you would want heading correction for this kind of control.
+        return run(() -> {
+            double xInput = Math.pow(translationX.getAsDouble(), 3); // Smooth control out
+            double yInput = Math.pow(translationY.getAsDouble(), 3); // Smooth control out
+            // Make the robot move
+            driveFieldOriented(swerveDrive.swerveController.getTargetSpeeds(xInput, yInput,
+                    headingX.getAsDouble(),
+                    headingY.getAsDouble(),
+                    swerveDrive.getYaw().getRadians(),
+                    swerveDrive.getMaximumVelocity()));
+        });
+    }
+
+    /**
+     * Command to drive the robot using translative values and heading as a setpoint.
+     *
+     * @param translationX Translation in the X direction.
+     * @param translationY Translation in the Y direction.
+     * @param rotation     Rotation as a value between [-1, 1] converted to radians.
+     * @return Drive command.
+     */
+    public Command simDriveCommand(DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier rotation) {
+        // swerveDrive.setHeadingCorrection(true); // Normally you would want heading correction for this kind of control.
+        return run(() -> {
+            // Make the robot move
+            driveFieldOriented(swerveDrive.swerveController.getTargetSpeeds(translationX.getAsDouble(),
+                    translationY.getAsDouble(),
+                    rotation.getAsDouble() * Math.PI,
+                    swerveDrive.getYaw().getRadians(),
+                    swerveDrive.getMaximumVelocity()));
+        });
+    }
+
+    /**
+     * Command to drive the robot using translative values and heading as angular velocity.
+     *
+     * @param translationX     Translation in the X direction. Cubed for smoother controls.
+     * @param translationY     Translation in the Y direction. Cubed for smoother controls.
+     * @param angularRotationX Angular velocity of the robot to set. Cubed for smoother controls.
+     * @return Drive command.
+     */
+    public Command driveCommand(DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier angularRotationX) {
+        return run(() -> {
+            // Make the robot move
+            swerveDrive.drive(new Translation2d(Math.pow(translationX.getAsDouble(), 3) * swerveDrive.getMaximumVelocity(),
+                            Math.pow(translationY.getAsDouble(), 3) * swerveDrive.getMaximumVelocity()),
+                    Math.pow(angularRotationX.getAsDouble(), 3) * swerveDrive.getMaximumAngularVelocity(),
+                    true,
+                    false);
+        });
+    }
+
+    /**
+     * The primary method for controlling the drivebase. Takes a {@link Translation2d} and a rotation rate.
+     * Can also be robot- or field-relative, affecting how the translation vector is applied.
+     *
+     * @param translation {@link Translation2d} that is the commanded linear velocity of the robot, in meters per
+     *    *                      second. In robot-relative mode, positive x is towards the bow (front) and positive y is
+     *    *                      towards port (left). In field-relative mode, positive x is away from the alliance wall
+     *    *                      (field North) and positive y is towards the left wall when looking through the driver station
+     *    *                      glass (field West).
+     * @param rotation The robot's angular rotation rate, in radians (degrees * (π/180)) per second. Unaffected by
+     *                 robot/field relativity.
+     * @param fieldRelative Drive mode. True for field-relative, false for robot-relative.
+     */
+    public void drive(Translation2d translation, double rotation, boolean fieldRelative) {
+        swerveDrive.drive(
+                translation,
+                rotation,
+                fieldRelative,
+                false);
+    }
+
+    /**
+     * Drives the robot given a chassis field-oriented velocity
+     *
+     * @param velocity Velocity according to the field
+     */
+    public void driveFieldOriented(ChassisSpeeds velocity) {
+        swerveDrive.driveFieldOriented(velocity);
+    }
+
+    /**
+     * Drive according to the chassis robot oriented velocity.
+     *
+     * @param velocity Robot oriented {@link ChassisSpeeds}
+     */
+    public void drive(ChassisSpeeds velocity) {
+        swerveDrive.drive(velocity);
+    }
+
+    /**
+     * Gets the heading (yaw) from the IMU
+     * @return The heading, as a {@link Rotation2d}
+     */
+    public Rotation2d getHeading() {
+        return swerveDrive.getYaw();
+    }
+
+    /**
+     * Gets the current pose (position and rotation) of the robot, as reported by odometry.
+     *
+     * @return The robot's pose
+     */
+    public Pose2d getPose() {
+        return swerveDrive.getPose();
+    }
+
+    /**
+     * Get the chassis speeds based on controller input of 1 joystick and one angle. Control the robot at an offset of
+     * 90deg.
+     *
+     * @param xInput X joystick input for the robot to move in the X direction.
+     * @param yInput Y joystick input for the robot to move in the Y direction.
+     * @param angle  The angle in as a {@link Rotation2d}.
+     * @return {@link ChassisSpeeds} which can be sent to th Swerve Drive.
+     */
+    public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, Rotation2d angle) {
+        xInput = Math.pow(xInput, 3);
+        yInput = Math.pow(yInput, 3);
+        return swerveDrive.swerveController.getTargetSpeeds(xInput,
+                yInput,
+                angle.getRadians(),
+                getHeading().getRadians(),
+                SwerveDrivetrainConstants.maximumSpeed);
+    }
+
+    /**
+     * Gets the current field-relative velocity (x, y and omega) of the robot
+     *
+     * @return A ChassisSpeeds object of the current field-relative velocity
+     */
+    public ChassisSpeeds getFieldVelocity() {
+        return swerveDrive.getFieldVelocity();
+    }
+
+    /**
+     * Resets the gyro angle to zero and resets odometry to the same position, but facing toward 0.
+     */
+    public void zeroGyro() {
+        swerveDrive.zeroGyro();
+    }
+
+    /**
+     * Resets odometry to the given pose. Gyro angle and module positions do not need to be reset when calling this
+     * method.  However, if either gyro angle or module position is reset, this must be called in order for odometry to
+     * keep working.
+     *
+     * @param initialHolonomicPose The pose to set the odometry to
+     */
+    public void resetOdometry(Pose2d initialHolonomicPose) {
+        swerveDrive.resetOdometry(initialHolonomicPose);
+    }
+
+    /**
+     * Gets the {@link SwerveController} used by the swerve drive
+     * @return The {@link SwerveController} used by the swerve drive
+     */
+    public SwerveController getSwerveController() {
+        return swerveDrive.getSwerveController();
+    }
+
+    /**
+     * Gets the maximum velocity achievable by the robot
+     * @return The maximum velocity, in meters per second
+     */
+    public double getMaximumVelocity() {
+        return swerveDrive.getMaximumVelocity();
+    }
+
+    public double getMaximumAngularVelocity() {
+        return swerveDrive.getMaximumAngularVelocity();
+    }
+
+    /**
+     * Get the {@link SwerveDriveConfiguration} object.
+     *
+     * @return The {@link SwerveDriveConfiguration} fpr the current drive.
+     */
+    public SwerveDriveConfiguration getSwerveDriveConfiguration() {
+        return swerveDrive.swerveDriveConfiguration;
+    }
+
+    public SwerveDrive getSwerveDrive() {
+        return swerveDrive;
+    }
+
+    /**
+     * Get the chassis speeds based on controller input of 2 joysticks. One for speeds in which direction. The other for
+     * the angle of the robot.
+     *
+     * @param xInput   X joystick input for the robot to move in the X direction.
+     * @param yInput   Y joystick input for the robot to move in the Y direction.
+     * @param headingX X joystick which controls the angle of the robot.
+     * @param headingY Y joystick which controls the angle of the robot.
+     * @return {@link ChassisSpeeds} which can be sent to th Swerve Drive.
+     */
+    public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, double headingX, double headingY) {
+        xInput = Math.pow(xInput, 3);
+        yInput = Math.pow(yInput, 3);
+        return swerveDrive.swerveController.getTargetSpeeds(xInput,
+                yInput,
+                headingX,
+                headingY,
+                getHeading().getRadians(),
+                SwerveDrivetrainConstants.maximumSpeed);
     }
 }


### PR DESCRIPTION
Each are stored in swerve.teleopControls in the commands folder
* DriveRotatedCommand drives the robot relative to the field, and uses the right stick or DPad to set its rotation. It is currently bound to the A button.
* DriveRotationCommand drives the robot relative to the field, and uses the right stick to spin. It is currently bound to the B button.
* DriveRobotRelative drives the robot relative to itself, where up is forward and left is right-to-left, and the right stick spins. It is currently bound to the X button.